### PR TITLE
Fix broken link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and the experiences and suggestions of team members.   Please give
 ## Table of Contents ##
 - [Code Lay-out](#code-lay-out)
 - [Imports](#imports)
-- [Whitespace in Expressions and Statements](#whitespace-in-expressions)
+- [Whitespace in Expressions and Statements](#whitespace-in-expressions-and-statements)
 - [Comments](#comments)
 - [Documentation Strings](#documentation-strings)
 - [Naming Conventions](#naming-conventions)


### PR DESCRIPTION
The link for the  `whitespace in expressions and statements` section is broken.