### PR TITLE
Add C coding style guideline

### DIFF
--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -552,7 +552,6 @@ int fun(int a)
 	buffer = kmalloc(SIZE, GFP_KERNEL);
 	if (!buffer) {
 		return -ENOMEM;
-
 	}
 
 	do_stuff();

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -14,8 +14,8 @@ Please at least consider the points made here."
 - [Introduction](#introduction)
 - [Indentation](#indentation)
 - [Breaking long lines and strings](#long-lines)
-- [Whitespace in Expressions and Statements](#whitespace-in-expressions-and-statements)
-- [Comments](#comments)
+- [Placing braces and spaces](#braces-and-spaces)
+- [Spaces](#spaces)
 - [Documentation Strings](#documentation-strings)
 - [Naming Conventions](#naming-conventions)
 - [Programming Recommendations](#programming-recommendations)
@@ -153,7 +153,7 @@ a long argument list. However, never break user-visible strings such as
 them.
 
 <a name="braces-and-spaces"/></a>
-# 3\) Placing Braces and Spaces
+# 3\) Placing braces and spaces
 
 The other issue that always comes up in C styling is the placement of
 braces. Unlike the indent size, there are few technical reasons to
@@ -162,24 +162,28 @@ shown to us by the prophets Kernighan and Ritchie, is to put the opening
 brace last on the line, and put the closing brace first, thusly:
 
 ``` c
-if (x is true) {
-    we do y
+/* good */
+if (x_is_true) {
+	we_do_y();
 }
 ```
 
-This applies to all non-function statement blocks (if, switch, for,
-while, do). E.g.:
+This applies to all non-function statement blocks (`if`, `switch`, `for`,
+`while`, `do`).
+
+e.g.:
 
 ``` c
+/* good */
 switch (action) {
 case KOBJ_ADD:
-    return "add";
+	return "add";
 case KOBJ_REMOVE:
-    return "remove";
+	return "remove";
 case KOBJ_CHANGE:
-    return "change";
+	return "change";
 default:
-    return NULL;
+	return NULL;
 }
 ```
 
@@ -187,9 +191,10 @@ However, there is one special case, namely functions: they have the
 opening brace at the beginning of the next line, thus:
 
 ``` c
+/* good */
 int function(int x)
 {
-    body of function
+	body of function
 }
 ```
 
@@ -200,73 +205,84 @@ special anyway (you can't nest them in C).
 
 Note that the closing brace is empty on a line of its own, **except** in
 the cases where it is followed by a continuation of the same statement,
-ie a `while` in a do-statement or an `else` in an if-statement, like
+i.e. a `while` in a do-statement or an `else` in an if-statement, like
 this:
 
 ``` c
+/* good */
 do {
-    body of do-loop
+	body_of_do_loop();
 } while (condition);
 ```
 
 and
 
 ``` c
+/* good */
 if (x == y) {
-    ..
+	foo();
 } else if (x > y) {
-    ...
+	bar();
 } else {
-    ....
+	baz();
 }
 ```
 
-Rationale: K\&R.
+**Rationale:** K\&R2.
 
-Also, note that this brace-placement also minimizes the number of empty
-(or almost empty) lines, without any loss of readability. Thus, as the
-supply of new-lines on your screen is not a renewable resource (think
-25-line terminal screens here), you have more empty lines to put
-comments on.
+It's also useful to note that this brace-placement minimizes the number of
+empty (or almost empty) lines, without any loss of readability. Thus, as the
+supply of newlines on your screen is not a renewable resource (think 25-line
+terminal screens here), you have more empty lines to put comments on.
 
-Do not unnecessarily use braces where a single statement will do.
+Use braces even for single statements:
 
 ``` c
-if (condition)
-    action();
+/* good */
+if (condition) {
+	action();
+}
 ```
 
 and
 
-``` sourceCode none
-if (condition)
-    do_this();
-else
-    do_that();
-```
-
-This does not apply if only one branch of a conditional statement is a
-single statement; in the latter case use braces in both branches:
-
 ``` c
+/* good */
 if (condition) {
-    do_this();
-    do_that();
+	do_this();
 } else {
-    otherwise();
+	do_that();
 }
 ```
 
-Also, use braces when a loop contains more than a single simple
-statement:
+**Rationale:** Everyone makes mistakes, but some mistakes, as shown by Apple's ["goto fail"](https://nakedsecurity.sophos.com/2014/02/24/anatomy-of-a-goto-fail-apples-ssl-bug-explained-plus-an-unofficial-patch/):
 
 ``` c
-while (condition) {
-    if (test)
-        do_something();
-}
+/* BAD BAD BAD */
+hashOut.data = hashes + SSL_MD5_DIGEST_LEN;
+hashOut.length = SSL_SHA1_DIGEST_LEN;
+if ((err = SSLFreeBuffer(&hashCtx)) != 0)
+    goto fail;
+if ((err = ReadyHash(&SSLHashSHA1, &hashCtx)) != 0)
+    goto fail;
+if ((err = SSLHashSHA1.update(&hashCtx, &clientRandom)) != 0)
+    goto fail;
+if ((err = SSLHashSHA1.update(&hashCtx, &serverRandom)) != 0)
+    goto fail;
+if ((err = SSLHashSHA1.update(&hashCtx, &signedParams)) != 0)
+    goto fail;
+    goto fail;  /* MISTAKE! THIS LINE SHOULD NOT BE HERE */
+if ((err = SSLHashSHA1.final(&hashCtx, &hashOut)) != 0)
+    goto fail;
+
+err = sslRawVerify(...);
 ```
 
+are very easily prevented.
+
+It's **always** better to code defensively, no matter how careful you **think** you are.
+
+<a name="spaces"/></a>
 ## 3.1) Spaces
 
 Linux kernel style for use of spaces depends (mostly) on

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -704,7 +704,7 @@ the code and it's prone to breakage from seemingly innocent changes.
 c\) Macros with arguments that are used as lvalues:
 
 ```c
-/* bad */
+/* BAD */
 FOO(x) = y;
 ```
 

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -664,11 +664,11 @@ resembles a function call):
 
 ```c
 /* good */
-#define macrofun(a, b, c)		\
-	do {						\
+#define macrofun(a, b, c)			\
+	do {					\
 		if ((a) == 5) {			\
 			do_this((b), (c));	\
-		}						\
+		}				\
 	} while (0)
 ```
 
@@ -678,12 +678,12 @@ a\) Macros that affect control flow:
 
 ```c
 /* good */
-#define FOO(x)							\
-	do {								\
+#define FOO(x)					\
+	do {					\
 		int i = (x) & FATAL_SIG_MASK;	\
-		if (blah(i) < 0) {				\
-			return -EBUGGERED;			\
-		}								\
+		if (blah(i) < 0) {		\
+			return -EBUGGERED;	\
+		}				\
 	} while (0)
 ```
 
@@ -726,10 +726,10 @@ resembling functions (such as GNU statement expressions):
 ```c
 /* BAD */
 #define FOO(x)			\
-({						\
+({				\
 	typeof(x) ret;		\
 	ret = calc_ret(x);	\
-	(ret);				\
+	(ret);			\
 })
 ```
 

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -50,27 +50,28 @@ code, and when you stop unconsciously judging code by its style you start
 judging code by its **worth**. Mistakes start to jump out at you, and you begin to
 see useful patterns that can be applied to other areas of the codebase.
 
-So please do keep this in mind while reading this document; there is a
-higher purpose to all of this, I promise. And even more important to keep
-in mind is that these are all **guidelines** and not unbreakable rules. They
-are meant to help, not oppress, so if breaking a rule or two keeps your
-code from becoming a jumbled mess, don't hesitate to do so. For example,
-it's almost certainly possible for single 90 character conditional to be
-easier read than a shorter, but multi-line, one. There will **always** exceptions
-like this for the guidelines which follow, and we are all intelligent adults
-here who can judgment calls when required, so never be afraid to exercise
-common sense.
+So please keep that in mind while reading this document; there is a higher
+purpose to all of this, I promise.
+
+Finally, remember that these are all **guidelines** and not unbreakable
+rules. They are meant to help, not oppress, so if breaking a rule or
+two keeps your code from becoming a jumbled mess, don't hesitate to do
+so. It's almost certainly possible for single 90 character conditional
+to be easier read than a shorter, but multi-line, one. There will **always**
+exceptions like this for the guidelines which follow, and we are all
+intelligent adults here who can judgment calls when required, so never
+be afraid to exercise common sense.
 
 Nonetheless, if there are any guidelines here which you absolutely cannot
 stand, or if there are any grave pragmatic or security concerns regarding any
 of these guidelines, please don't hesitate to direct any feedback to
-@alyptik
+@alyptik (Joey Pabalinas <joeypabalinas@gmail.com>).
 
-About half of the document is verbatim from the Linux kernel coding
-style (of which I am a staunch believer in, as you cout probably tell), but
-there are guidelines which I felt need to be modified to better reflect the
-difference in goals and types of codebases worked on by the NYU Tandon School
-of Engineering.
+About half of the document is verbatim from the Linux kernel coding style
+guidelines (of which I am a staunch believer in, as you can probably
+tell), but there were guidelines which I felt need to be modified to better
+reflect the differences in goals and project types worked on by the NYU Tandon
+School of Engineering.
 
 <a name="indentation"/></a>
 # 1\) Indentation
@@ -455,7 +456,6 @@ useful only for:
 
 	   When editing existing code which already uses one or the other set
 	   of types, you should conform to the existing choices in that code.
-
 
 Maybe there are other cases too, but the rule should basically be to
 NEVER EVER use a typedef unless you can clearly match one of those

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -17,6 +17,7 @@ Please at least consider the points made here."
 - [Placing braces and spaces](#braces-and-spaces)
 - [Spaces](#spaces)
 - [Naming](#naming)
+- [Typedefs](#typedefs)
 
 <a name="introduction"/></a>
 # Introduction
@@ -288,7 +289,7 @@ alignof, and \_\_attribute\_\_, when using the form resembling functions.
 
 So use a space after these keywords:
 
-	if, switch, case, for, do, while
+> if, switch, case, for, do, while
 
 but not with the function-resembling forms of sizeof, typeof, alignof,
 or \_\_attribute\_\_. E.g.,
@@ -320,19 +321,19 @@ char *match_strdup(substring_t *s);
 Use one space around (on each side of) most binary and ternary
 operators, such as any of these:
 
-	=  +  -  <  >  *  /  %  |  &  ^  <=  >=  ==  !=  ?  :
+> =  +  -  <  >  *  /  %  |  &  ^  <=  >=  ==  !=  ?  :
 
 but no space after unary operators:
 
-	&  *  +  -  ~  !  sizeof  typeof  alignof  __attribute__  defined
+> &  *  +  -  ~  !  sizeof  typeof  alignof  __attribute__  defined
 
 no space before the postfix increment & decrement unary operators:
 
-	++  --
+> ++  --
 
 no space after the prefix increment & decrement unary operators:
 
-	++  --
+> ++  --
 
 and no space around the `.` and `->` structure member operators.
 
@@ -354,46 +355,48 @@ fail by changing their context lines.
 C is a Spartan language, and so should your naming be. Unlike Modula-2
 and Pascal programmers, C programmers do not use cute names like
 ThisVariableIsATemporaryCounter. A C programmer would call that variable
-`tmp`, which is much easier to write, and not the least more difficult
+`cnt`, which is much easier to write, and not the least more difficult
 to understand.
 
 HOWEVER, while mixed-case names are frowned upon, descriptive names for
-global variables are a must. To call a global function `foo` is a
-shooting offense.
+file-scope identifiers are a must. To call an externally visible function
+`f()` is a shooting offense.
 
-GLOBAL variables (to be used only if you **really** need them) need to
-have descriptive names, as do global functions. If you have a function
-that counts the number of active users, you should call that
-`count_active_users()` or similar, you should **not** call it
-`cntusr()`.
+**FILE-SCOPE** variables (to be used only if you **really** need them) need to
+have descriptive names, as do functions. If you have a function that counts
+the number of active users, you should call that `count_active_users()` or
+similar, you should **not** call it `cntusr()`.
 
 Encoding the type of a function into the name (so-called Hungarian
-notation) is brain damaged - the compiler knows the types anyway and can
-check those, and it only confuses the programmer. No wonder MicroSoft
-makes buggy programs.
+notation) is pointless --- the compiler knows the types anyway and can
+check those, so it only serves to confuse the programmer.
 
-LOCAL variable names should be short, and to the point. If you have some
+**LOCAL** variable names should be short, and to the point. If you have some
 random integer loop counter, it should probably be called `i`. Calling
-it `loop_counter` is non-productive, if there is no chance of it being
+it `loop_counter` is non-productive if there is no chance of it being
 mis-understood. Similarly, `tmp` can be just about any type of variable
 that is used to hold a temporary value.
 
 If you are afraid to mix up your local variable names, you have another
 problem, which is called the function-growth-hormone-imbalance syndrome.
-See chapter 6 (Functions).
+See section 6 ([Functions](#functions)).
 
+<a name="typedefs"/></a>
 # 5\) Typedefs
 
-Please don't use things like `vps_t`. It's a **mistake** to use typedef
-for structures and pointers. When you see a
+Please don't use things like `vps_t`. It's a **mistake** to use `typedef`
+for non-opaque structures and pointers. When you see a
 
 ``` c
+/* BAD */
 vps_t a;
 ```
 
-in the source, what does it mean? In contrast, if it says
+in the source, what does it mean? Is it a `struct`? A `union`? A function
+pointer? In contrast, if it says
 
 ``` c
+/* good */
 struct virtual_container *a;
 ```
 

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -4,7 +4,8 @@ These guidelines provide examples of what to do (or not to do) when writing
 C code for the projects of the [Secure Systems Lab](https://ssl.engineering.nyu.edu/)
 in the NYU Tandon School of Engineering.
 
-These guidelines are based on a document describing [the preferred coding style](https://www.kernel.org/doc/html/v4.10/process/coding-style.html)
+These guidelines are based on a document describing
+[the preferred coding style](https://www.kernel.org/doc/html/v4.17/process/coding-style.html)
 for the Linux kernel. As the document states:
 
 > "Coding style is very personal, and I won't **force** my views on anybody

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -18,6 +18,7 @@ Please at least consider the points made here."
 - [Spaces](#spaces)
 - [Naming](#naming)
 - [Typedefs](#typedefs)
+- [Functions](#functions)
 
 <a name="introduction"/></a>
 # Introduction
@@ -368,7 +369,7 @@ the number of active users, you should call that `count_active_users()` or
 similar, you should **not** call it `cntusr()`.
 
 Encoding the type of a function into the name (so-called Hungarian
-notation) is pointless --- the compiler knows the types anyway and can
+notation) is pointless - the compiler knows the types anyway and can
 check those, so it only serves to confuse the programmer.
 
 **LOCAL** variable names should be short, and to the point. If you have some
@@ -402,80 +403,47 @@ struct virtual_container *a;
 
 you can actually tell what `a` is.
 
-Lots of people think that typedefs `help readability`. Not so. They are
+Lots of people think that typedefs help readability. Not so. They are
 useful only for:
 
-> 1)  totally opaque objects (where the typedef is actively used to
->     **hide** what the object is).
->     
->     Example: `pte_t` etc. opaque objects that you can only access
->     using the proper accessor functions.
->     
->     <div class="note">
->     
->     <div class="admonition-title">
->     
->     Note
->     
->     </div>
->     
->     Opaqueness and `accessor functions` are not good in themselves.
->     The reason we have them for things like pte\_t etc. is that there
->     really is absolutely **zero** portably accessible information
->     there.
->     
->     </div>
-> 
-> 2)  Clear integer types, where the abstraction **helps** avoid
->     confusion whether it is `int` or `long`.
->     
->     u8/u16/u32 are perfectly fine typedefs, although they fit into
->     category (d) better than here.
->     
->     <div class="note">
->     
->     <div class="admonition-title">
->     
->     Note
->     
->     </div>
->     
->     Again - there needs to be a **reason** for this. If something is
->     `unsigned long`, then there's no reason to do
->     
->     </div>
-> 
-> > typedef unsigned long myflags\_t;
-> > 
-> > > but if there is a clear reason for why it under certain
-> > > circumstances might be an `unsigned int` and under other
-> > > configurations might be `unsigned long`, then by all means go
-> > > ahead and use a typedef.
-> 
-> 3)  when you use sparse to literally create a **new** type for
->     type-checking.
-> 
-> 4)  New types which are identical to standard C99 types, in certain
->     exceptional circumstances.
->     
->     Although it would only take a short amount of time for the eyes
->     and brain to become accustomed to the standard types like
->     `uint32_t`, some people object to their use anyway.
->     
->     Therefore, the Linux-specific `u8/u16/u32/u64` types and their
->     signed equivalents which are identical to standard types are
->     permitted -- although they are not mandatory in new code of your
->     own.
->     
->     When editing existing code which already uses one or the other set
->     of types, you should conform to the existing choices in that code.
-> 
-> 5)  Types safe for use in userspace.
->     
->     In certain structures which are visible to userspace, we cannot
->     require C99 types and cannot use the `u32` form above. Thus, we
->     use \_\_u32 and similar types in all structures which are shared
->     with userspace.
+	a) Totally opaque objects (where the typedef is actively used to
+	   *_hide_ what the object is).
+
+	   Example: `pte_t` etc. opaque objects that you can only access
+	   using the proper accessor functions.
+
+	   Opaqueness and `accessor functions` are not good in themselves.
+	   The reason we have them for things like `pte_t` etc. is that there
+	   really is absolutely _zero_ portably accessible information
+	   there.
+
+	b) Clear integer types, where the abstraction _helps_ avoid
+	   confusion whether it is `int` or `long`.
+
+	   u8/u16/u32 are perfectly fine typedefs, although they fit into
+	   category (c) better than here.
+
+	   Again - there needs to be a reason for this. If something is
+	   `unsigned long`, then there's no reason to typedef,
+	   but if under certain circumstances it might be an `unsigned int`
+	   and under other configurations might be `unsigned long`, then
+	   by all means go ahead and use a typedef.
+
+	c) New types which are identical to standard C99 types, in certain
+	   exceptional circumstances.
+
+	   Although it would only take a short amount of time for the eyes
+	   and brain to become accustomed to the standard types like
+	   `uint32_t`, some people object to their use anyway.
+
+	   Therefore, the Linux-specific `u8/u16/u32/u64` types and their
+	   signed equivalents which are identical to standard types are
+	   permitted - although they are not mandatory in new code of your
+	   own.
+
+	   When editing existing code which already uses one or the other set
+	   of types, you should conform to the existing choices in that code.
+
 
 Maybe there are other cases too, but the rule should basically be to
 NEVER EVER use a typedef unless you can clearly match one of those
@@ -484,6 +452,7 @@ rules.
 In general, a pointer, or a struct that has elements that can reasonably
 be directly accessed should **never** be a typedef.
 
+<a name="functions"/></a>
 # 6\) Functions
 
 Functions should be short and sweet, and do just one thing. They should

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -119,7 +119,7 @@ to hide:
 ``` c
 /* BAD */
 if (condition) do_this;
-  do_something_everytime;
+ do_something_everytime;
 ```
 
 Don't put multiple assignments on a single line either. Avoid tricky

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -79,7 +79,7 @@ School of Engineering.
 Tabs are 8 characters, and thus indentations are also 8 characters.
 There are heretic movements that try to make indentations 4 (or even
 2\!) characters deep, and that is akin to trying to define the value of
-π to be 3.
+pi to be 3.
 
 **Rationale:** The whole idea behind indentation is to clearly define where
 a block of control starts and ends. Especially when you've been looking
@@ -209,7 +209,7 @@ int function(int x)
 ```
 
 Heretic people all over the world have claimed that this inconsistency
-is ... well ... inconsistent, but all right-thinking people know that
+is … well … inconsistent, but all right-thinking people know that
 (a) K\&R are **right** and (b) K\&R are right. Besides, functions are
 special anyway (you can't nest them in C).
 
@@ -285,7 +285,7 @@ if ((err = SSLHashSHA1.update(&hashCtx, &signedParams)) != 0)
 if ((err = SSLHashSHA1.final(&hashCtx, &hashOut)) != 0)
     goto fail;
 
-err = sslRawVerify(...);
+err = sslRawVerify(…);
 ```
 
 are very easily prevented.
@@ -296,15 +296,15 @@ It's **always** better to code defensively, no matter how careful you **think** 
 ## 3.1) Spaces
 
 The use of spaces depends (mostly) on function-versus-keyword usage. Use a
-space after (most) keywords. The notable exceptions are sizeof, typeof,
-alignof, and \_\_attribute\_\_, when using the form resembling functions.
+space after (most) keywords. The notable exceptions are `sizeof()`, `typeof()`,
+`alignof()`, and `__attribute__()`, when using the form resembling functions.
 
 So use a space after these keywords:
 
 > if, switch, case, for, do, while
 
-but not with the function-resembling forms of sizeof, typeof, alignof,
-or \_\_attribute\_\_.
+but not with the function-resembling forms of `sizeof()`, `typeof()`,
+`alignof()`, and `__attribute__()`.
 
 e.g.:
 
@@ -339,7 +339,7 @@ operators, such as any of these:
 
 but no space after unary operators:
 
-> &  *  +  -  ~  !  sizeof  typeof  alignof  __attribute__  defined
+> &  *  +  -  ~  !  `sizeof()`  `typeof()`  `alignof()`  `__attribute__()`  `defined()`
 
 no space before the postfix increment & decrement unary operators:
 
@@ -368,7 +368,7 @@ fail by changing their context lines.
 
 C is a Spartan language, and so should your naming be. Unlike Modula-2
 and Pascal programmers, C programmers do not use cute names like
-ThisVariableIsATemporaryCounter. A C programmer would call that variable
+`ThisVariableIsATemporaryCounter`. A C programmer would call that variable
 `cnt`, which is much easier to write, and not the least more difficult
 to understand.
 
@@ -388,7 +388,7 @@ check those, so it only serves to confuse the programmer.
 **LOCAL** variable names should be short, and to the point. If you have some
 random integer loop counter, it should probably be called `i`. Calling
 it `loop_counter` is non-productive if there is no chance of it being
-mis-understood. Similarly, `tmp` can be just about any type of variable
+misunderstood. Similarly, `tmp` can be just about any type of variable
 that is used to hold a temporary value.
 
 If you are afraid to mix up your local variable names, you have another
@@ -433,7 +433,7 @@ useful only for:
 	b) Clear integer types, where the abstraction _helps_ avoid
 	   confusion whether it is `int` or `long`.
 
-	   u8/u16/u32 are perfectly fine typedefs, although they fit into
+	   `u8`/`u16`/`u32` are perfectly fine typedefs, although they fit into
 	   category (c) better than here.
 
 	   Again - there needs to be a reason for this. If something is
@@ -751,7 +751,7 @@ success).
 Mixing up these two sorts of representations is a fertile source of
 difficult-to-find bugs. If the C language included a strong distinction
 between integers and booleans then the compiler would find these
-mistakes for us... but it doesn't. To help prevent such bugs, always
+mistakes for us… but it doesn't. To help prevent such bugs, always
 follow this convention:
 
 > If the name of a function is an action or an imperative command,
@@ -782,18 +782,18 @@ files. The compiler will avoid generating any code for the stub calls,
 producing identical results, but the logic will remain easy to follow.
 
 Prefer to compile out entire functions, rather than portions of
-functions or portions of expressions. Rather than putting an ifdef in an
+functions or portions of expressions. Rather than putting an `#ifdef` in an
 expression, factor out part or all of the expression into a separate
 helper function and apply the conditional to that function.
 
 At the end of any non-trivial `#if` or `#ifdef` block (more than a few
-lines), place a comment after the \#endif on the same line, noting the
+lines), place a comment after the `#endif` on the same line, noting the
 conditional expression used. For instance:
 
 ``` c
 /* good */
 #ifdef CONFIG_SOMETHING
-...
+…
 #endif /* CONFIG_SOMETHING */
 ```
 <a name="references"/></a>

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -66,7 +66,7 @@ be afraid to exercise common sense.
 Nonetheless, if there are any guidelines here which you absolutely cannot
 stand, or if there are any grave pragmatic or security concerns regarding any
 of these guidelines, please don't hesitate to direct any feedback to
-@alyptik (Joey Pabalinas <joeypabalinas@gmail.com>).
+[@alyptik](https://github.com/alyptik) (Joey Pabalinas \<<joeypabalinas@gmail.com>\>).
 
 About half of the document is verbatim from the Linux kernel coding style
 guidelines (of which I am a staunch believer in, as you can probably
@@ -139,9 +139,8 @@ diffs more, well, difficult, and most editors these days have features
 to quickly remove all trailing whitespace from a document.
 
 Outside of comments and documentation, spaces should never be used for
-indentation, and the above example is deliberately broken. It's much
-easier to avoid mixed and incorrect indentation with tabs, as well as
-to modify or remove indentation levels.
+indentation. It's much easier to avoid mixed and incorrect indentation
+with tabs, as well as to modify or remove indentation levels.
 
 <a name="long-lines"/></a>
 # 2\) Breaking long lines and strings

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -5,10 +5,12 @@ C code for the projects of the [Secure Systems Lab](https://ssl.engineering.nyu.
 in the NYU Tandon School of Engineering.
 
 These guidelines are based on a document describing [the preferred coding style](https://www.kernel.org/doc/html/v4.10/process/coding-style.html)
-for the Linux kernel. As the document states, "coding style is very personal,
-and I won't **force** my views on anybody, but this is what goes for anything that
-I have to be able to maintain, and I'd prefer it for most other things too.
-Please at least consider the points made here."
+for the Linux kernel. As the document states:
+
+> "Coding style is very personal, and I won't **force** my views on anybody
+> but this is what goes for anything that I have to be able to maintain, and
+> I'd prefer it for most other things too. Please at least consider the points
+> made here."
 
 ## Table of Contents ##
 - [Introduction](#introduction)

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -1,0 +1,1125 @@
+# Code Style Guidelines #
+
+These guidelines provide examples of what to do (or not to do) when writing
+C code for the projects of the [Secure Systems Lab](https://ssl.engineering.nyu.edu/)
+in the NYU Tandon School of Engineering.
+
+These guidelines are based on a document describing [the preferred coding style](https://www.kernel.org/doc/html/v4.10/process/coding-style.html)
+for the Linux kernel. As the document states, "coding style is very personal,
+and I won't **force** my views on anybody, but this is what goes for anything that
+I have to be able to maintain, and I'd prefer it for most other things too.
+Please at least consider the points made here."
+
+## Table of Contents ##
+- [Introduction](#introduction)
+- [Indentation](#indentation)
+- [Breaking long lines and strings](#long-lines)
+- [Whitespace in Expressions and Statements](#whitespace-in-expressions-and-statements)
+- [Comments](#comments)
+- [Documentation Strings](#documentation-strings)
+- [Naming Conventions](#naming-conventions)
+- [Programming Recommendations](#programming-recommendations)
+- [Potpourri](#potpourri)
+
+<a name="introduction"/></a>
+# Introduction
+
+You might think the main point of having a consistent coding style is to
+have a legible, easy-to-mentally-parse template which everyone follows, and
+yes, this is definitely one of the more useful side-effects, but it isn't most
+important reason by far.
+
+Humans are quite effective at recognizing patterns; it's one of the main
+reasons why we find it so easy to do things which are excruciatingly difficult
+for computers (all those exhilarating CAPTCHAs where you are tasked with
+finding all the pictures containing cars comes to mind), and this is just
+as true when it comes to reading computer code; both our own as well as
+code written by others.
+
+When reading code with consistent style, the repetitiveness tricks you into
+tuning out the style completely: your brain no longer considers it important
+to care about and you are able to see the deeper structure and semantics of
+code, and when you stop unconsciously judging code by its style you start
+judging code by its **worth**. Mistakes start to jump out at you, and you begin to
+see useful patterns that can be applied to other areas of the codebase.
+
+So please do keep this in mind while reading this document; there is a
+higher purpose to all of this, I promise. And even more important to keep
+in mind is that these are all **guidelines** and not unbreakable rules. They
+are meant to help, not oppress, so if breaking a rule or two keeps your
+code from becoming a jumbled mess, don't hesitate to do so. For example,
+it's almost certainly possible for single 90 character conditional to be
+easier read than a shorter, but multi-line, one. There will **always** exceptions
+like this for the guidelines which follow, and we are all intelligent adults
+here who can judgment calls when required, so never be afraid to exercise
+common sense.
+
+Nonetheless, if there are any guidelines here which you absolutely cannot
+stand, or if there are any grave pragmatic or security concerns regarding any
+of these guidelines, please don't hesitate to direct any feedback to
+@alyptik
+
+About half of the document is verbatim from the Linux kernel coding
+style (of which I am a staunch believer in, as you cout probably tell), but
+there are guidelines which I felt need to be modified to better reflect the
+difference in goals and types of codebases worked on by the NYU Tandon School
+of Engineering.
+
+<a name="indentation"/></a>
+# 1\) Indentation
+
+Tabs are 8 characters, and thus indentations are also 8 characters.
+There are heretic movements that try to make indentations 4 (or even
+2\!) characters deep, and that is akin to trying to define the value of
+PI to be 3.
+
+Rationale: The whole idea behind indentation is to clearly define where
+a block of control starts and ends. Especially when you've been looking
+at your screen for 20 straight hours, you'll find it a lot easier to see
+how the indentation works if you have large indentations.
+
+Now, some people will claim that having 8-character indentations makes
+the code move too far to the right, and makes it hard to read on a
+80-character terminal screen. The answer to that is that if you need
+more than 3 levels of indentation, you're screwed anyway, and should fix
+your program.
+
+In short, 8-char indents make things easier to read, and have the added
+benefit of warning you when you're nesting your functions too deep. Heed
+that warning.
+
+The preferred way to ease multiple indentation levels in a switch
+statement is to align the `switch` and its subordinate `case` labels in
+the same column instead of `double-indenting` the `case` labels. E.g.:
+
+``` c
+switch (suffix) {
+case 'G':
+case 'g':
+    mem <<= 30;
+    break;
+case 'M':
+case 'm':
+    mem <<= 20;
+    break;
+case 'K':
+case 'k':
+    mem <<= 10;
+    /* fall through */
+default:
+    break;
+}
+```
+
+Don't put multiple statements on a single line unless you have something
+to hide:
+
+``` c
+if (condition) do_this;
+  do_something_everytime;
+```
+
+Don't put multiple assignments on a single line either. Kernel coding
+style is super simple. Avoid tricky expressions.
+
+Outside of comments, documentation and except in Kconfig, spaces are
+never used for indentation, and the above example is deliberately
+broken.
+
+Get a decent editor and don't leave whitespace at the end of lines.
+
+# 2\) Breaking long lines and strings
+
+Coding style is all about readability and maintainability using commonly
+available tools.
+
+The limit on the length of lines is 80 columns and this is a strongly
+preferred limit.
+
+Statements longer than 80 columns will be broken into sensible chunks,
+unless exceeding 80 columns significantly increases readability and does
+not hide information. Descendants are always substantially shorter than
+the parent and are placed substantially to the right. The same applies
+to function headers with a long argument list. However, never break
+user-visible strings such as printk messages, because that breaks the
+ability to grep for them.
+
+# 3\) Placing Braces and Spaces
+
+The other issue that always comes up in C styling is the placement of
+braces. Unlike the indent size, there are few technical reasons to
+choose one placement strategy over the other, but the preferred way, as
+shown to us by the prophets Kernighan and Ritchie, is to put the opening
+brace last on the line, and put the closing brace first, thusly:
+
+``` c
+if (x is true) {
+    we do y
+}
+```
+
+This applies to all non-function statement blocks (if, switch, for,
+while, do). E.g.:
+
+``` c
+switch (action) {
+case KOBJ_ADD:
+    return "add";
+case KOBJ_REMOVE:
+    return "remove";
+case KOBJ_CHANGE:
+    return "change";
+default:
+    return NULL;
+}
+```
+
+However, there is one special case, namely functions: they have the
+opening brace at the beginning of the next line, thus:
+
+``` c
+int function(int x)
+{
+    body of function
+}
+```
+
+Heretic people all over the world have claimed that this inconsistency
+is ... well ... inconsistent, but all right-thinking people know that
+(a) K\&R are **right** and (b) K\&R are right. Besides, functions are
+special anyway (you can't nest them in C).
+
+Note that the closing brace is empty on a line of its own, **except** in
+the cases where it is followed by a continuation of the same statement,
+ie a `while` in a do-statement or an `else` in an if-statement, like
+this:
+
+``` c
+do {
+    body of do-loop
+} while (condition);
+```
+
+and
+
+``` c
+if (x == y) {
+    ..
+} else if (x > y) {
+    ...
+} else {
+    ....
+}
+```
+
+Rationale: K\&R.
+
+Also, note that this brace-placement also minimizes the number of empty
+(or almost empty) lines, without any loss of readability. Thus, as the
+supply of new-lines on your screen is not a renewable resource (think
+25-line terminal screens here), you have more empty lines to put
+comments on.
+
+Do not unnecessarily use braces where a single statement will do.
+
+``` c
+if (condition)
+    action();
+```
+
+and
+
+``` sourceCode none
+if (condition)
+    do_this();
+else
+    do_that();
+```
+
+This does not apply if only one branch of a conditional statement is a
+single statement; in the latter case use braces in both branches:
+
+``` c
+if (condition) {
+    do_this();
+    do_that();
+} else {
+    otherwise();
+}
+```
+
+Also, use braces when a loop contains more than a single simple
+statement:
+
+``` c
+while (condition) {
+    if (test)
+        do_something();
+}
+```
+
+## 3.1) Spaces
+
+Linux kernel style for use of spaces depends (mostly) on
+function-versus-keyword usage. Use a space after (most) keywords. The
+notable exceptions are sizeof, typeof, alignof, and \_\_attribute\_\_,
+which look somewhat like functions (and are usually used with
+parentheses in Linux, although they are not required in the language, as
+in: `sizeof info` after `struct fileinfo info;` is declared).
+
+So use a space after these keywords:
+
+    if, switch, case, for, do, while
+
+but not with sizeof, typeof, alignof, or \_\_attribute\_\_. E.g.,
+
+``` c
+s = sizeof(struct file);
+```
+
+Do not add spaces around (inside) parenthesized expressions. This
+example is **bad**:
+
+``` c
+s = sizeof( struct file );
+```
+
+When declaring pointer data or a function that returns a pointer type,
+the preferred use of `*` is adjacent to the data name or function name
+and not adjacent to the type name. Examples:
+
+``` c
+char *linux_banner;
+unsigned long long memparse(char *ptr, char **retptr);
+char *match_strdup(substring_t *s);
+```
+
+Use one space around (on each side of) most binary and ternary
+operators, such as any of these:
+
+    =  +  -  <  >  *  /  %  |  &  ^  <=  >=  ==  !=  ?  :
+
+but no space after unary operators:
+
+    &  *  +  -  ~  !  sizeof  typeof  alignof  __attribute__  defined
+
+no space before the postfix increment & decrement unary operators:
+
+    ++  --
+
+no space after the prefix increment & decrement unary operators:
+
+    ++  --
+
+and no space around the `.` and `->` structure member operators.
+
+Do not leave trailing whitespace at the ends of lines. Some editors with
+`smart` indentation will insert whitespace at the beginning of new lines
+as appropriate, so you can start typing the next line of code right
+away. However, some such editors do not remove the whitespace if you end
+up not putting a line of code there, such as if you leave a blank line.
+As a result, you end up with lines containing trailing whitespace.
+
+Git will warn you about patches that introduce trailing whitespace, and
+can optionally strip the trailing whitespace for you; however, if
+applying a series of patches, this may make later patches in the series
+fail by changing their context lines.
+
+# 4\) Naming
+
+C is a Spartan language, and so should your naming be. Unlike Modula-2
+and Pascal programmers, C programmers do not use cute names like
+ThisVariableIsATemporaryCounter. A C programmer would call that variable
+`tmp`, which is much easier to write, and not the least more difficult
+to understand.
+
+HOWEVER, while mixed-case names are frowned upon, descriptive names for
+global variables are a must. To call a global function `foo` is a
+shooting offense.
+
+GLOBAL variables (to be used only if you **really** need them) need to
+have descriptive names, as do global functions. If you have a function
+that counts the number of active users, you should call that
+`count_active_users()` or similar, you should **not** call it
+`cntusr()`.
+
+Encoding the type of a function into the name (so-called Hungarian
+notation) is brain damaged - the compiler knows the types anyway and can
+check those, and it only confuses the programmer. No wonder MicroSoft
+makes buggy programs.
+
+LOCAL variable names should be short, and to the point. If you have some
+random integer loop counter, it should probably be called `i`. Calling
+it `loop_counter` is non-productive, if there is no chance of it being
+mis-understood. Similarly, `tmp` can be just about any type of variable
+that is used to hold a temporary value.
+
+If you are afraid to mix up your local variable names, you have another
+problem, which is called the function-growth-hormone-imbalance syndrome.
+See chapter 6 (Functions).
+
+# 5\) Typedefs
+
+Please don't use things like `vps_t`. It's a **mistake** to use typedef
+for structures and pointers. When you see a
+
+``` c
+vps_t a;
+```
+
+in the source, what does it mean? In contrast, if it says
+
+``` c
+struct virtual_container *a;
+```
+
+you can actually tell what `a` is.
+
+Lots of people think that typedefs `help readability`. Not so. They are
+useful only for:
+
+> 1)  totally opaque objects (where the typedef is actively used to
+>     **hide** what the object is).
+>     
+>     Example: `pte_t` etc. opaque objects that you can only access
+>     using the proper accessor functions.
+>     
+>     <div class="note">
+>     
+>     <div class="admonition-title">
+>     
+>     Note
+>     
+>     </div>
+>     
+>     Opaqueness and `accessor functions` are not good in themselves.
+>     The reason we have them for things like pte\_t etc. is that there
+>     really is absolutely **zero** portably accessible information
+>     there.
+>     
+>     </div>
+> 
+> 2)  Clear integer types, where the abstraction **helps** avoid
+>     confusion whether it is `int` or `long`.
+>     
+>     u8/u16/u32 are perfectly fine typedefs, although they fit into
+>     category (d) better than here.
+>     
+>     <div class="note">
+>     
+>     <div class="admonition-title">
+>     
+>     Note
+>     
+>     </div>
+>     
+>     Again - there needs to be a **reason** for this. If something is
+>     `unsigned long`, then there's no reason to do
+>     
+>     </div>
+> 
+> > typedef unsigned long myflags\_t;
+> > 
+> > > but if there is a clear reason for why it under certain
+> > > circumstances might be an `unsigned int` and under other
+> > > configurations might be `unsigned long`, then by all means go
+> > > ahead and use a typedef.
+> 
+> 3)  when you use sparse to literally create a **new** type for
+>     type-checking.
+> 
+> 4)  New types which are identical to standard C99 types, in certain
+>     exceptional circumstances.
+>     
+>     Although it would only take a short amount of time for the eyes
+>     and brain to become accustomed to the standard types like
+>     `uint32_t`, some people object to their use anyway.
+>     
+>     Therefore, the Linux-specific `u8/u16/u32/u64` types and their
+>     signed equivalents which are identical to standard types are
+>     permitted -- although they are not mandatory in new code of your
+>     own.
+>     
+>     When editing existing code which already uses one or the other set
+>     of types, you should conform to the existing choices in that code.
+> 
+> 5)  Types safe for use in userspace.
+>     
+>     In certain structures which are visible to userspace, we cannot
+>     require C99 types and cannot use the `u32` form above. Thus, we
+>     use \_\_u32 and similar types in all structures which are shared
+>     with userspace.
+
+Maybe there are other cases too, but the rule should basically be to
+NEVER EVER use a typedef unless you can clearly match one of those
+rules.
+
+In general, a pointer, or a struct that has elements that can reasonably
+be directly accessed should **never** be a typedef.
+
+# 6\) Functions
+
+Functions should be short and sweet, and do just one thing. They should
+fit on one or two screenfuls of text (the ISO/ANSI screen size is 80x24,
+as we all know), and do one thing and do that well.
+
+The maximum length of a function is inversely proportional to the
+complexity and indentation level of that function. So, if you have a
+conceptually simple function that is just one long (but simple)
+case-statement, where you have to do lots of small things for a lot of
+different cases, it's OK to have a longer function.
+
+However, if you have a complex function, and you suspect that a
+less-than-gifted first-year high-school student might not even
+understand what the function is all about, you should adhere to the
+maximum limits all the more closely. Use helper functions with
+descriptive names (you can ask the compiler to in-line them if you think
+it's performance-critical, and it will probably do a better job of it
+than you would have done).
+
+Another measure of the function is the number of local variables. They
+shouldn't exceed 5-10, or you're doing something wrong. Re-think the
+function, and split it into smaller pieces. A human brain can generally
+easily keep track of about 7 different things, anything more and it gets
+confused. You know you're brilliant, but maybe you'd like to understand
+what you did 2 weeks from now.
+
+In source files, separate functions with one blank line. If the function
+is exported, the **EXPORT** macro for it should follow immediately after
+the closing function brace line. E.g.:
+
+``` c
+int system_is_up(void)
+{
+    return system_state == SYSTEM_RUNNING;
+}
+EXPORT_SYMBOL(system_is_up);
+```
+
+In function prototypes, include parameter names with their data types.
+Although this is not required by the C language, it is preferred in
+Linux because it is a simple way to add valuable information for the
+reader.
+
+# 7\) Centralized exiting of functions
+
+Albeit deprecated by some people, the equivalent of the goto statement
+is used frequently by compilers in form of the unconditional jump
+instruction.
+
+The goto statement comes in handy when a function exits from multiple
+locations and some common work such as cleanup has to be done. If there
+is no cleanup needed then just return directly.
+
+Choose label names which say what the goto does or why the goto exists.
+An example of a good name could be `out_free_buffer:` if the goto frees
+`buffer`. Avoid using GW-BASIC names like `err1:` and `err2:`, as you
+would have to renumber them if you ever add or remove exit paths, and
+they make correctness difficult to verify anyway.
+
+The rationale for using gotos is:
+
+  - unconditional statements are easier to understand and follow
+  - nesting is reduced
+  - errors by not updating individual exit points when making
+    modifications are prevented
+  - saves the compiler work to optimize redundant code away ;)
+
+<!-- end list -->
+
+``` c
+int fun(int a)
+{
+    int result = 0;
+    char *buffer;
+
+    buffer = kmalloc(SIZE, GFP_KERNEL);
+    if (!buffer)
+        return -ENOMEM;
+
+    if (condition1) {
+        while (loop1) {
+            ...
+        }
+        result = 1;
+        goto out_free_buffer;
+    }
+    ...
+out_free_buffer:
+    kfree(buffer);
+    return result;
+}
+```
+
+A common type of bug to be aware of is `one err bugs` which look like
+this:
+
+``` c
+err:
+    kfree(foo->bar);
+    kfree(foo);
+    return ret;
+```
+
+The bug in this code is that on some exit paths `foo` is NULL. Normally
+the fix for this is to split it up into two error labels `err_free_bar:`
+and `err_free_foo:`:
+
+``` c
+err_free_bar:
+   kfree(foo->bar);
+err_free_foo:
+   kfree(foo);
+   return ret;
+```
+
+Ideally you should simulate errors to test all exit paths.
+
+# 8\) Commenting
+
+Comments are good, but there is also a danger of over-commenting. NEVER
+try to explain HOW your code works in a comment: it's much better to
+write the code so that the **working** is obvious, and it's a waste of
+time to explain badly written code.
+
+Generally, you want your comments to tell WHAT your code does, not HOW.
+Also, try to avoid putting comments inside a function body: if the
+function is so complex that you need to separately comment parts of it,
+you should probably go back to chapter 6 for a while. You can make small
+comments to note or warn about something particularly clever (or ugly),
+but try to avoid excess. Instead, put the comments at the head of the
+function, telling people what it does, and possibly WHY it does it.
+
+When commenting the kernel API functions, please use the kernel-doc
+format. See the files at <span data-role="ref">Documentation/doc-guide/
+\<doc\_guide\></span> and `scripts/kernel-doc` for details.
+
+The preferred style for long (multi-line) comments is:
+
+``` c
+/*
+ * This is the preferred style for multi-line
+ * comments in the Linux kernel source code.
+ * Please use it consistently.
+ *
+ * Description:  A column of asterisks on the left side,
+ * with beginning and ending almost-blank lines.
+ */
+```
+
+For files in net/ and drivers/net/ the preferred style for long
+(multi-line) comments is a little different.
+
+``` c
+/* The preferred comment style for files in net/ and drivers/net
+ * looks like this.
+ *
+ * It is nearly the same as the generally preferred comment style,
+ * but there is no initial almost-blank line.
+ */
+```
+
+It's also important to comment data, whether they are basic types or
+derived types. To this end, use just one data declaration per line (no
+commas for multiple data declarations). This leaves you room for a small
+comment on each item, explaining its use.
+
+# 9\) You've made a mess of it
+
+That's OK, we all do. You've probably been told by your long-time Unix
+user helper that `GNU emacs` automatically formats the C sources for
+you, and you've noticed that yes, it does do that, but the defaults it
+uses are less than desirable (in fact, they are worse than random typing
+- an infinite number of monkeys typing into GNU emacs would never make a
+good program).
+
+So, you can either get rid of GNU emacs, or change it to use saner
+values. To do the latter, you can stick the following in your .emacs
+file:
+
+``` sourceCode none
+(defun c-lineup-arglist-tabs-only (ignored)
+  "Line up argument lists by tabs, not spaces"
+  (let* ((anchor (c-langelem-pos c-syntactic-element))
+         (column (c-langelem-2nd-pos c-syntactic-element))
+         (offset (- (1+ column) anchor))
+         (steps (floor offset c-basic-offset)))
+    (* (max steps 1)
+       c-basic-offset)))
+
+(add-hook 'c-mode-common-hook
+          (lambda ()
+            ;; Add kernel style
+            (c-add-style
+             "linux-tabs-only"
+             '("linux" (c-offsets-alist
+                        (arglist-cont-nonempty
+                         c-lineup-gcc-asm-reg
+                         c-lineup-arglist-tabs-only))))))
+
+(add-hook 'c-mode-hook
+          (lambda ()
+            (let ((filename (buffer-file-name)))
+              ;; Enable kernel mode for the appropriate files
+              (when (and filename
+                         (string-match (expand-file-name "~/src/linux-trees")
+                                       filename))
+                (setq indent-tabs-mode t)
+                (setq show-trailing-whitespace t)
+                (c-set-style "linux-tabs-only")))))
+```
+
+This will make emacs go better with the kernel coding style for C files
+below `~/src/linux-trees`.
+
+But even if you fail in getting emacs to do sane formatting, not
+everything is lost: use `indent`.
+
+Now, again, GNU indent has the same brain-dead settings that GNU emacs
+has, which is why you need to give it a few command line options.
+However, that's not too bad, because even the makers of GNU indent
+recognize the authority of K\&R (the GNU people aren't evil, they are
+just severely misguided in this matter), so you just give indent the
+options `-kr -i8` (stands for `K&R, 8 character indents`), or use
+`scripts/Lindent`, which indents in the latest style.
+
+`indent` has a lot of options, and especially when it comes to comment
+re-formatting you may want to take a look at the man page. But remember:
+`indent` is not a fix for bad programming.
+
+Note that you can also use the `clang-format` tool to help you with
+these rules, to quickly re-format parts of your code automatically, and
+to review full files in order to spot coding style mistakes, typos and
+possible improvements. It is also handy for sorting `#includes`, for
+aligning variables/macros, for reflowing text and other similar tasks.
+See the file
+<span data-role="ref">Documentation/process/clang-format.rst
+\<clangformat\></span> for more details.
+
+# 10\) Kconfig configuration files
+
+For all of the Kconfig\* configuration files throughout the source tree,
+the indentation is somewhat different. Lines under a `config` definition
+are indented with one tab, while help text is indented an additional two
+spaces. Example:
+
+    config AUDIT
+      bool "Auditing support"
+      depends on NET
+      help
+        Enable auditing infrastructure that can be used with another
+        kernel subsystem, such as SELinux (which requires this for
+        logging of avc messages output).  Does not do system-call
+        auditing without CONFIG_AUDITSYSCALL.
+
+Seriously dangerous features (such as write support for certain
+filesystems) should advertise this prominently in their prompt string:
+
+    config ADFS_FS_RW
+      bool "ADFS write support (DANGEROUS)"
+      depends on ADFS_FS
+      ...
+
+For full documentation on the configuration files, see the file
+Documentation/kbuild/kconfig-language.txt.
+
+# 11\) Data structures
+
+Data structures that have visibility outside the single-threaded
+environment they are created and destroyed in should always have
+reference counts. In the kernel, garbage collection doesn't exist (and
+outside the kernel garbage collection is slow and inefficient), which
+means that you absolutely **have** to reference count all your uses.
+
+Reference counting means that you can avoid locking, and allows multiple
+users to have access to the data structure in parallel - and not having
+to worry about the structure suddenly going away from under them just
+because they slept or did something else for a while.
+
+Note that locking is **not** a replacement for reference counting.
+Locking is used to keep data structures coherent, while reference
+counting is a memory management technique. Usually both are needed, and
+they are not to be confused with each other.
+
+Many data structures can indeed have two levels of reference counting,
+when there are users of different `classes`. The subclass count counts
+the number of subclass users, and decrements the global count just once
+when the subclass count goes to zero.
+
+Examples of this kind of `multi-level-reference-counting` can be found
+in memory management (`struct mm_struct`: mm\_users and mm\_count), and
+in filesystem code (`struct super_block`: s\_count and s\_active).
+
+Remember: if another thread can find your data structure, and you don't
+have a reference count on it, you almost certainly have a bug.
+
+# 12\) Macros, Enums and RTL
+
+Names of macros defining constants and labels in enums are capitalized.
+
+``` c
+#define CONSTANT 0x12345
+```
+
+Enums are preferred when defining several related constants.
+
+CAPITALIZED macro names are appreciated but macros resembling functions
+may be named in lower case.
+
+Generally, inline functions are preferable to macros resembling
+functions.
+
+Macros with multiple statements should be enclosed in a do - while
+block:
+
+``` c
+#define macrofun(a, b, c)           \
+    do {                    \
+        if (a == 5)         \
+            do_this(b, c);      \
+    } while (0)
+```
+
+Things to avoid when using macros:
+
+1)  macros that affect control flow:
+
+<!-- end list -->
+
+``` c
+#define FOO(x)                  \
+    do {                    \
+        if (blah(x) < 0)        \
+            return -EBUGGERED;  \
+    } while (0)
+```
+
+is a **very** bad idea. It looks like a function call but exits the
+`calling` function; don't break the internal parsers of those who will
+read the code.
+
+2)  macros that depend on having a local variable with a magic name:
+
+<!-- end list -->
+
+``` c
+#define FOO(val) bar(index, val)
+```
+
+might look like a good thing, but it's confusing as hell when one reads
+the code and it's prone to breakage from seemingly innocent changes.
+
+3\) macros with arguments that are used as l-values: FOO(x) = y; will
+bite you if somebody e.g. turns FOO into an inline function.
+
+4\) forgetting about precedence: macros defining constants using
+expressions must enclose the expression in parentheses. Beware of
+similar issues with macros using parameters.
+
+``` c
+#define CONSTANT 0x4000
+#define CONSTEXP (CONSTANT | 3)
+```
+
+5\) namespace collisions when defining local variables in macros
+resembling functions:
+
+``` c
+#define FOO(x)              \
+({                  \
+    typeof(x) ret;          \
+    ret = calc_ret(x);      \
+    (ret);              \
+})
+```
+
+ret is a common name for a local variable - \_\_foo\_ret is less likely
+to collide with an existing variable.
+
+The cpp manual deals with macros exhaustively. The gcc internals manual
+also covers RTL which is used frequently with assembly language in the
+kernel.
+
+# 13\) Printing kernel messages
+
+Kernel developers like to be seen as literate. Do mind the spelling of
+kernel messages to make a good impression. Do not use crippled words
+like `dont`; use `do not` or `don't` instead. Make the messages concise,
+clear, and unambiguous.
+
+Kernel messages do not have to be terminated with a period.
+
+Printing numbers in parentheses (%d) adds no value and should be
+avoided.
+
+There are a number of driver model diagnostic macros in
+\<linux/device.h\> which you should use to make sure messages are
+matched to the right device and driver, and are tagged with the right
+level: dev\_err(), dev\_warn(), dev\_info(), and so forth. For messages
+that aren't associated with a particular device, \<linux/printk.h\>
+defines pr\_notice(), pr\_info(), pr\_warn(), pr\_err(), etc.
+
+Coming up with good debugging messages can be quite a challenge; and
+once you have them, they can be a huge help for remote troubleshooting.
+However debug message printing is handled differently than printing
+other non-debug messages. While the other pr\_XXX() functions print
+unconditionally, pr\_debug() does not; it is compiled out by default,
+unless either DEBUG is defined or CONFIG\_DYNAMIC\_DEBUG is set. That is
+true for dev\_dbg() also, and a related convention uses VERBOSE\_DEBUG
+to add dev\_vdbg() messages to the ones already enabled by DEBUG.
+
+Many subsystems have Kconfig debug options to turn on -DDEBUG in the
+corresponding Makefile; in other cases specific files \#define DEBUG.
+And when a debug message should be unconditionally printed, such as if
+it is already inside a debug-related \#ifdef section, printk(KERN\_DEBUG
+...) can be used.
+
+# 14\) Allocating memory
+
+The kernel provides the following general purpose memory allocators:
+kmalloc(), kzalloc(), kmalloc\_array(), kcalloc(), vmalloc(), and
+vzalloc(). Please refer to the API documentation for further information
+about them.
+
+The preferred form for passing a size of a struct is the following:
+
+``` c
+p = kmalloc(sizeof(*p), ...);
+```
+
+The alternative form where struct name is spelled out hurts readability
+and introduces an opportunity for a bug when the pointer variable type
+is changed but the corresponding sizeof that is passed to a memory
+allocator is not.
+
+Casting the return value which is a void pointer is redundant. The
+conversion from void pointer to any other pointer type is guaranteed by
+the C programming language.
+
+The preferred form for allocating an array is the following:
+
+``` c
+p = kmalloc_array(n, sizeof(...), ...);
+```
+
+The preferred form for allocating a zeroed array is the following:
+
+``` c
+p = kcalloc(n, sizeof(...), ...);
+```
+
+Both forms check for overflow on the allocation size n \* sizeof(...),
+and return NULL if that occurred.
+
+# 15\) The inline disease
+
+There appears to be a common misperception that gcc has a magic "make me
+faster" speedup option called `inline`. While the use of inlines can be
+appropriate (for example as a means of replacing macros, see Chapter
+12), it very often is not. Abundant use of the inline keyword leads to a
+much bigger kernel, which in turn slows the system as a whole down, due
+to a bigger icache footprint for the CPU and simply because there is
+less memory available for the pagecache. Just think about it; a
+pagecache miss causes a disk seek, which easily takes 5 milliseconds.
+There are a LOT of cpu cycles that can go into these 5 milliseconds.
+
+A reasonable rule of thumb is to not put inline at functions that have
+more than 3 lines of code in them. An exception to this rule are the
+cases where a parameter is known to be a compiletime constant, and as a
+result of this constantness you *know* the compiler will be able to
+optimize most of your function away at compile time. For a good example
+of this later case, see the kmalloc() inline function.
+
+Often people argue that adding inline to functions that are static and
+used only once is always a win since there is no space tradeoff. While
+this is technically correct, gcc is capable of inlining these
+automatically without help, and the maintenance issue of removing the
+inline when a second user appears outweighs the potential value of the
+hint that tells gcc to do something it would have done anyway.
+
+# 16\) Function return values and names
+
+Functions can return values of many different kinds, and one of the most
+common is a value indicating whether the function succeeded or failed.
+Such a value can be represented as an error-code integer (-Exxx =
+failure, 0 = success) or a `succeeded` boolean (0 = failure, non-zero =
+success).
+
+Mixing up these two sorts of representations is a fertile source of
+difficult-to-find bugs. If the C language included a strong distinction
+between integers and booleans then the compiler would find these
+mistakes for us... but it doesn't. To help prevent such bugs, always
+follow this convention:
+
+    If the name of a function is an action or an imperative command,
+    the function should return an error-code integer.  If the name
+    is a predicate, the function should return a "succeeded" boolean.
+
+For example, `add work` is a command, and the add\_work() function
+returns 0 for success or -EBUSY for failure. In the same way, `PCI
+device present` is a predicate, and the pci\_dev\_present() function
+returns 1 if it succeeds in finding a matching device or 0 if it
+doesn't.
+
+All EXPORTed functions must respect this convention, and so should all
+public functions. Private (static) functions need not, but it is
+recommended that they do.
+
+Functions whose return value is the actual result of a computation,
+rather than an indication of whether the computation succeeded, are not
+subject to this rule. Generally they indicate failure by returning some
+out-of-range result. Typical examples would be functions that return
+pointers; they use NULL or the ERR\_PTR mechanism to report failure.
+
+# 17\) Don't re-invent the kernel macros
+
+The header file include/linux/kernel.h contains a number of macros that
+you should use, rather than explicitly coding some variant of them
+yourself. For example, if you need to calculate the length of an array,
+take advantage of the macro
+
+``` c
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+```
+
+Similarly, if you need to calculate the size of some structure member,
+use
+
+``` c
+#define FIELD_SIZEOF(t, f) (sizeof(((t*)0)->f))
+```
+
+There are also min() and max() macros that do strict type checking if
+you need them. Feel free to peruse that header file to see what else is
+already defined that you shouldn't reproduce in your code.
+
+# 18\) Editor modelines and other cruft
+
+Some editors can interpret configuration information embedded in source
+files, indicated with special markers. For example, emacs interprets
+lines marked like this:
+
+``` c
+-*- mode: c -*-
+```
+
+Or like this:
+
+``` c
+/*
+Local Variables:
+compile-command: "gcc -DMAGIC_DEBUG_FLAG foo.c"
+End:
+*/
+```
+
+Vim interprets markers that look like this:
+
+``` c
+/* vim:set sw=8 noet */
+```
+
+Do not include any of these in source files. People have their own
+personal editor configurations, and your source files should not
+override them. This includes markers for indentation and mode
+configuration. People may use their own custom mode, or may have some
+other magic method for making indentation work correctly.
+
+# 19\) Inline assembly
+
+In architecture-specific code, you may need to use inline assembly to
+interface with CPU or platform functionality. Don't hesitate to do so
+when necessary. However, don't use inline assembly gratuitously when C
+can do the job. You can and should poke hardware from C when possible.
+
+Consider writing simple helper functions that wrap common bits of inline
+assembly, rather than repeatedly writing them with slight variations.
+Remember that inline assembly can use C parameters.
+
+Large, non-trivial assembly functions should go in .S files, with
+corresponding C prototypes defined in C header files. The C prototypes
+for assembly functions should use `asmlinkage`.
+
+You may need to mark your asm statement as volatile, to prevent GCC from
+removing it if GCC doesn't notice any side effects. You don't always
+need to do so, though, and doing so unnecessarily can limit
+optimization.
+
+When writing a single inline assembly statement containing multiple
+instructions, put each instruction on a separate line in a separate
+quoted string, and end each string except the last with `\n\t` to
+properly indent the next instruction in the assembly output:
+
+``` c
+asm ("magic %reg1, #42\n\t"
+     "more_magic %reg2, %reg3"
+     : /* outputs */ : /* inputs */ : /* clobbers */);
+```
+
+# 20\) Conditional Compilation
+
+Wherever possible, don't use preprocessor conditionals (\#if, \#ifdef)
+in .c files; doing so makes code harder to read and logic harder to
+follow. Instead, use such conditionals in a header file defining
+functions for use in those .c files, providing no-op stub versions in
+the \#else case, and then call those functions unconditionally from .c
+files. The compiler will avoid generating any code for the stub calls,
+producing identical results, but the logic will remain easy to follow.
+
+Prefer to compile out entire functions, rather than portions of
+functions or portions of expressions. Rather than putting an ifdef in an
+expression, factor out part or all of the expression into a separate
+helper function and apply the conditional to that function.
+
+If you have a function or variable which may potentially go unused in a
+particular configuration, and the compiler would warn about its
+definition going unused, mark the definition as \_\_maybe\_unused rather
+than wrapping it in a preprocessor conditional. (However, if a function
+or variable *always* goes unused, delete it.)
+
+Within code, where possible, use the IS\_ENABLED macro to convert a
+Kconfig symbol into a C boolean expression, and use it in a normal C
+conditional:
+
+``` c
+if (IS_ENABLED(CONFIG_SOMETHING)) {
+    ...
+}
+```
+
+The compiler will constant-fold the conditional away, and include or
+exclude the block of code just as with an \#ifdef, so this will not add
+any runtime overhead. However, this approach still allows the C compiler
+to see the code inside the block, and check it for correctness (syntax,
+types, symbol references, etc). Thus, you still have to use an \#ifdef
+if the code inside the block references symbols that will not exist if
+the condition is not met.
+
+At the end of any non-trivial \#if or \#ifdef block (more than a few
+lines), place a comment after the \#endif on the same line, noting the
+conditional expression used. For instance:
+
+``` c
+#ifdef CONFIG_SOMETHING
+...
+#endif /* CONFIG_SOMETHING */
+```
+
+# Appendix I) References
+
+The C Programming Language, Second Edition by Brian W. Kernighan and
+Dennis M. Ritchie. Prentice Hall, Inc., 1988. ISBN 0-13-110362-8
+(paperback), 0-13-110370-9 (hardback).
+
+The Practice of Programming by Brian W. Kernighan and Rob Pike.
+Addison-Wesley, Inc., 1999. ISBN 0-201-61586-X.
+
+GNU manuals - where in compliance with K\&R and this text - for cpp,
+gcc, gcc internals and indent, all available from
+<http://www.gnu.org/manual/>
+
+WG14 is the international standardization working group for the
+programming language C, URL: <http://www.open-std.org/JTC1/SC22/WG14/>
+
+Kernel process/coding-style.rst, by <greg@kroah.com> at OLS 2002:
+<http://www.kroah.com/linux/talks/ols_2002_kernel_codingstyle_talk/html/>

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -19,6 +19,7 @@ Please at least consider the points made here."
 - [Naming](#naming)
 - [Typedefs](#typedefs)
 - [Functions](#functions)
+- [Centralized exiting of functions](#function-exit)
 
 <a name="introduction"/></a>
 # Introduction
@@ -90,7 +91,9 @@ Heed that warning.
 
 The preferred way to ease multiple indentation levels in a switch
 statement is to align the `switch` and its subordinate `case` labels in
-the same column instead of `double-indenting` the `case` labels. E.g.:
+the same column instead of `double-indenting` the `case` labels.
+
+e.g.:
 
 ``` c
 /* good */
@@ -293,7 +296,9 @@ So use a space after these keywords:
 > if, switch, case, for, do, while
 
 but not with the function-resembling forms of sizeof, typeof, alignof,
-or \_\_attribute\_\_. E.g.,
+or \_\_attribute\_\_.
+
+e.g.:
 
 ``` c
 /* good */
@@ -469,34 +474,39 @@ However, if you have a complex function, and you suspect that a
 less-than-gifted first-year high-school student might not even
 understand what the function is all about, you should adhere to the
 maximum limits all the more closely. Use helper functions with
-descriptive names (you can ask the compiler to in-line them if you think
+descriptive names (you can ask the compiler to `inline` them if you think
 it's performance-critical, and it will probably do a better job of it
 than you would have done).
 
 Another measure of the function is the number of local variables. They
 shouldn't exceed 5-10, or you're doing something wrong. Re-think the
-function, and split it into smaller pieces. A human brain can generally
-easily keep track of about 7 different things, anything more and it gets
-confused. You know you're brilliant, but maybe you'd like to understand
-what you did 2 weeks from now.
+function, and split it into smaller pieces. A human brain in general can
+easily keep track of about 7 different things, but anything more and it
+gets confused. You know you're brilliant, but maybe you'd like to
+understand what you did 2 weeks from now.
 
-In source files, separate functions with one blank line. If the function
-is exported, the **EXPORT** macro for it should follow immediately after
-the closing function brace line. E.g.:
+In source files, separate functions with one blank line.
 
-``` c
+e.g.:
+
+```c
+/* good */
 int system_is_up(void)
 {
     return system_state == SYSTEM_RUNNING;
 }
-EXPORT_SYMBOL(system_is_up);
+
+int system_is_dowm(void)
+{
+    return system_state == SYSTEM_DOWN;
+}
 ```
 
 In function prototypes, include parameter names with their data types.
-Although this is not required by the C language, it is preferred in
-Linux because it is a simple way to add valuable information for the
-reader.
+Although this is not required by the C language, it is preferred because
+it is a simple way to add valuable information for the reader.
 
+<a name="function-exit"/></a>
 # 7\) Centralized exiting of functions
 
 Albeit deprecated by some people, the equivalent of the goto statement

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -661,7 +661,7 @@ resembles a function call):
 
 ##### Things to avoid when using macros:
 
-a\) Macros that affect control flow:
+a) Macros that affect control flow:
 
 ```c
 /* good */
@@ -678,24 +678,24 @@ are a **very** bad idea. It looks like a function call but exits the
 **calling** function; don't break the mental parsers of those who will
 read the code.
 
-b\) Macros that depend on having a local variable with a magic name:
+b) Macros that depend on having a local variable with a magic name:
 
 ```c
 /* BAD */
-#define FOO(val) bar(magic_index, val)
+#define FOO(val) bar(magic_index, (val))
 ```
 
 might look like a good thing, but it's confusing as hell when one reads
 the code and it's prone to breakage from seemingly innocent changes.
 
-c\) Macros with arguments that are used as lvalues:
+c) Macros with arguments that are used as lvalues:
 
 ```c
 /* BAD */
 FOO(x) = y;
 ```
 
-**will** bite you if somebody e.g. turns `FOO()` into an inline function.
+**will** bite you if somebody changes `FOO()` into an inline function.
 
 d\) Forgetting about precedence: macros defining constants using
 expressions must enclose the expression in parentheses. Beware of
@@ -707,21 +707,30 @@ similar issues with macros using parameters.
 #define CONSTEXP (SOME_CONSTANT|OTHER_CONSTANT)
 ```
 
-e\) Namespace collisions when defining local variables in macros
+e) Namespace collisions when defining local variables in macros
 resembling functions (such as GNU statement expressions):
 
 ```c
 /* BAD */
-#define FOO(x)			\
-({				\
-	typeof(x) ret;		\
-	ret = calc_ret(x);	\
-	(ret);			\
-})
+#define STATEMENT_EXPR(x)		\
+	({				\
+		typeof(x) ret;		\
+		ret = calc_ret(x);	\
+		(ret);			\
+	})
 ```
 
-`ret` is a common name for a local variable - `__foo_ret` is less likely
+`ret` is a common name for a local variable - `__max_ret` is less likely
 to collide with an existing variable.
+```c
+/* good */
+#define STATEMENT_EXPR(x)					\
+	({							\
+		typeof(x) __max_ret;				\
+		__max_ret = max_t(typeof(x), (x), FD_MAX);	\
+		(__max_ret);					\
+	})
+```
 
 <a name="function-return-and-names"/></a>
 # 10\) Function return values and names

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -43,12 +43,13 @@ finding all the pictures containing cars comes to mind), and this is just
 as true when it comes to reading computer code; both our own as well as
 code written by others.
 
-When reading code with consistent style, the repetitiveness tricks you into
+When reading code with consistent style, its repetitiveness tricks you into
 tuning out the style completely: your brain no longer considers it important
-to care about and you are able to see the deeper structure and semantics of
-code, and when you stop unconsciously judging code by its style you start
-judging code by its **worth**. Mistakes start to jump out at you, and you begin to
-see useful patterns that can be applied to other areas of the codebase.
+important to bother caring about and you begin to notice strange code structure
+or missing semantics. When you stop unconsciously judging code by how much you
+like or dislike its style you naturally start judging code by its **worth
+instead**. Mistakes start to jump out at you, and you begin to see useful,
+reusable solutions that you had previously overlooked.
 
 So please keep that in mind while reading this document; there is a higher
 purpose to all of this, I promise.

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -16,10 +16,7 @@ Please at least consider the points made here."
 - [Breaking long lines and strings](#long-lines)
 - [Placing braces and spaces](#braces-and-spaces)
 - [Spaces](#spaces)
-- [Documentation Strings](#documentation-strings)
-- [Naming Conventions](#naming-conventions)
-- [Programming Recommendations](#programming-recommendations)
-- [Potpourri](#potpourri)
+- [Naming](#naming)
 
 <a name="introduction"/></a>
 # Introduction
@@ -285,20 +282,19 @@ It's **always** better to code defensively, no matter how careful you **think** 
 <a name="spaces"/></a>
 ## 3.1) Spaces
 
-Linux kernel style for use of spaces depends (mostly) on
-function-versus-keyword usage. Use a space after (most) keywords. The
-notable exceptions are sizeof, typeof, alignof, and \_\_attribute\_\_,
-which look somewhat like functions (and are usually used with
-parentheses in Linux, although they are not required in the language, as
-in: `sizeof info` after `struct fileinfo info;` is declared).
+The use of spaces depends (mostly) on function-versus-keyword usage. Use a
+space after (most) keywords. The notable exceptions are sizeof, typeof,
+alignof, and \_\_attribute\_\_, when using the form resembling functions.
 
 So use a space after these keywords:
 
-    if, switch, case, for, do, while
+	if, switch, case, for, do, while
 
-but not with sizeof, typeof, alignof, or \_\_attribute\_\_. E.g.,
+but not with the function-resembling forms of sizeof, typeof, alignof,
+or \_\_attribute\_\_. E.g.,
 
 ``` c
+/* good */
 s = sizeof(struct file);
 ```
 
@@ -306,6 +302,7 @@ Do not add spaces around (inside) parenthesized expressions. This
 example is **bad**:
 
 ``` c
+/* BAD */
 s = sizeof( struct file );
 ```
 
@@ -314,6 +311,7 @@ the preferred use of `*` is adjacent to the data name or function name
 and not adjacent to the type name. Examples:
 
 ``` c
+/* good */
 char *linux_banner;
 unsigned long long memparse(char *ptr, char **retptr);
 char *match_strdup(substring_t *s);
@@ -322,19 +320,19 @@ char *match_strdup(substring_t *s);
 Use one space around (on each side of) most binary and ternary
 operators, such as any of these:
 
-    =  +  -  <  >  *  /  %  |  &  ^  <=  >=  ==  !=  ?  :
+	=  +  -  <  >  *  /  %  |  &  ^  <=  >=  ==  !=  ?  :
 
 but no space after unary operators:
 
-    &  *  +  -  ~  !  sizeof  typeof  alignof  __attribute__  defined
+	&  *  +  -  ~  !  sizeof  typeof  alignof  __attribute__  defined
 
 no space before the postfix increment & decrement unary operators:
 
-    ++  --
+	++  --
 
 no space after the prefix increment & decrement unary operators:
 
-    ++  --
+	++  --
 
 and no space around the `.` and `->` structure member operators.
 
@@ -350,6 +348,7 @@ can optionally strip the trailing whitespace for you; however, if
 applying a series of patches, this may make later patches in the series
 fail by changing their context lines.
 
+<a name="naming"/></a>
 # 4\) Naming
 
 C is a Spartan language, and so should your naming be. Unlike Modula-2

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -539,8 +539,6 @@ The rationale for using gotos is:
 	  modifications are prevented.
 	- Saves the compiler work to optimize redundant code away.
 
-	<!-- end list -->
-
 So use them in situations like this to avoid making already confusing code
 even more complicated:
 

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -71,9 +71,9 @@ of Engineering.
 Tabs are 8 characters, and thus indentations are also 8 characters.
 There are heretic movements that try to make indentations 4 (or even
 2\!) characters deep, and that is akin to trying to define the value of
-PI to be 3.
+π to be 3.
 
-Rationale: The whole idea behind indentation is to clearly define where
+**Rationale:** The whole idea behind indentation is to clearly define where
 a block of control starts and ends. Especially when you've been looking
 at your screen for 20 straight hours, you'll find it a lot easier to see
 how the indentation works if you have large indentations.
@@ -84,30 +84,32 @@ the code move too far to the right, and makes it hard to read on a
 more than 3 levels of indentation, you're screwed anyway, and should fix
 your program.
 
-In short, 8-char indents make things easier to read, and have the added
-benefit of warning you when you're nesting your functions too deep. Heed
-that warning.
+In short, 8 character indents make things easier to read, and have the
+added benefit of warning you when you're nesting your code blocks too deep.
+
+Heed that warning.
 
 The preferred way to ease multiple indentation levels in a switch
 statement is to align the `switch` and its subordinate `case` labels in
 the same column instead of `double-indenting` the `case` labels. E.g.:
 
 ``` c
+/* good */
 switch (suffix) {
 case 'G':
 case 'g':
-    mem <<= 30;
-    break;
+	mem <<= 30;
+	break;
 case 'M':
 case 'm':
-    mem <<= 20;
-    break;
+	mem <<= 20;
+	break;
 case 'K':
 case 'k':
-    mem <<= 10;
-    /* fall through */
+	mem <<= 10;
+	/* fall through */
 default:
-    break;
+	break;
 }
 ```
 
@@ -115,19 +117,24 @@ Don't put multiple statements on a single line unless you have something
 to hide:
 
 ``` c
+/* BAD */
 if (condition) do_this;
   do_something_everytime;
 ```
 
-Don't put multiple assignments on a single line either. Kernel coding
-style is super simple. Avoid tricky expressions.
+Don't put multiple assignments on a single line either. Avoid tricky
+expressions. Keep your coding style simple, stupid™.
 
-Outside of comments, documentation and except in Kconfig, spaces are
-never used for indentation, and the above example is deliberately
-broken.
+Don't leave whitespace at the end of lines; they can make applying those
+diffs more, well, difficult, and most editors these days have features
+to quickly remove all trailing whitespace from a document.
 
-Get a decent editor and don't leave whitespace at the end of lines.
+Outside of comments and documentation, spaces should never be used for
+indentation, and the above example is deliberately broken. It's much
+easier to avoid mixed and incorrect indentation with tabs, as well as
+to modify or remove indentation levels.
 
+<a name="long-lines"/></a>
 # 2\) Breaking long lines and strings
 
 Coding style is all about readability and maintainability using commonly

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -209,10 +209,7 @@ int function(int x)
 }
 ```
 
-Heretic people all over the world have claimed that this inconsistency
-is … well … inconsistent, but all right-thinking people know that
-(a) K\&R are **right** and (b) K\&R are right. Besides, functions are
-special anyway (you can't nest them in C).
+Functions are special; you can't nest them in standard C.
 
 Note that the closing brace is empty on a line of its own, **except** in
 the cases where it is followed by a continuation of the same statement,

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -102,8 +102,6 @@ The preferred way to ease multiple indentation levels in a switch
 statement is to align the `switch` and its subordinate `case` labels in
 the same column instead of `double-indenting` the `case` labels.
 
-e.g.:
-
 ``` c
 /* good */
 switch (suffix) {
@@ -181,8 +179,6 @@ if (x_is_true) {
 
 This applies to all non-function statement blocks (`if`, `switch`, `for`,
 `while`, `do`).
-
-e.g.:
 
 ``` c
 /* good */
@@ -303,8 +299,6 @@ So use a space after these keywords:
 
 but not with the function-resembling forms of `sizeof()`, `typeof()`,
 `alignof()`, and `__attribute__()`.
-
-e.g.:
 
 ``` c
 /* good */
@@ -492,9 +486,6 @@ understand what you did 2 weeks from now.
 
 In source files, separate functions with one blank line.
 
-e.g.:
-
-
 ```c
 /* good */
 int system_is_up(void)
@@ -583,7 +574,6 @@ out_no_free:
 A common type of bug to be aware of are "one `err` bugs" which look like
 this:
 
-
 ``` c
 /* BAD */
 err:
@@ -658,7 +648,6 @@ macros resembling functions.
 Macros with multiple statements should be enclosed in a do - while block
 to allow it for a semicolon when used (so that `macrofun(x, y, z);`
 resembles a function call):
-
 
 ```c
 /* good */

--- a/c_coding_style.md
+++ b/c_coding_style.md
@@ -143,14 +143,16 @@ available tools.
 The limit on the length of lines is 80 columns and this is a strongly
 preferred limit.
 
-Statements longer than 80 columns will be broken into sensible chunks,
+Statements longer than 80 columns should be broken into sensible chunks,
 unless exceeding 80 columns significantly increases readability and does
-not hide information. Descendants are always substantially shorter than
-the parent and are placed substantially to the right. The same applies
-to function headers with a long argument list. However, never break
-user-visible strings such as printk messages, because that breaks the
-ability to grep for them.
+not hide information. If this happens to be the case, descendants should
+always be substantially shorter than the parent and should be placed
+substantially to the right. The same applies to function headers with
+a long argument list. However, never break user-visible strings such as
+`puts()` or `printf()` messages, because that breaks the ability to grep for
+them.
 
+<a name="braces-and-spaces"/></a>
 # 3\) Placing Braces and Spaces
 
 The other issue that always comes up in C styling is the placement of


### PR DESCRIPTION
I wasn't sure if you preferred the C guideline in a separate file or directory, so just let me know if there are any revisions you'd like me to make. 

The document was converted from the rST kernel style guide, revised to better fit NYU's code requirements, and I added a few conveniences like a ToC with working links.